### PR TITLE
remove local check for `playing` state in media rendererer client

### DIFF
--- a/src/mediarendererClient.ts
+++ b/src/mediarendererClient.ts
@@ -164,10 +164,6 @@ export class UpnpMediaRendererClient extends UpnpDeviceClient {
     };
 
     loadNext = (url: string, options: MediaRendererOptions): Promise<UpnpClientResponse> => {
-        if (!this.listening) {
-            throw new Error('No media was loaded first, use load method.');
-        }
-
         const params = {
             InstanceID: this.instanceId,
             NextURI: url,


### PR DESCRIPTION
No `playing` property does exist in `mediarendererClient` and the local check is redundant here anyway. 